### PR TITLE
[test action] Minor fixes: suppress warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,12 @@ include_directories(${PROJECT_SOURCE_DIR}/include/physics)
 set(libs)
 
 # OpenGL
+
+# use GLVND instead of legacy OpenGL
+if(POLICY CMP0072)
+  cmake_policy(SET CMP0072 NEW)
+endif()
+
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
 list(APPEND libs ${OPENGL_LIBRARIES})
@@ -80,30 +86,30 @@ endif()
 # VarTypes
 find_package(VarTypes)
 
-if(NOT VARTYPES_FOUND)
+if(NOT VarTypes_FOUND)
   include(ExternalProject)
-  set(VARTYPES_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/vartypes_install")
+  set(VarTypes_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/vartypes_install")
   
-  set(VARTYPES_CMAKE_ARGS "-DVARTYPES_BUILD_STATIC=ON;-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>")
+  set(VarTypes_CMAKE_ARGS "-DVarTypes_BUILD_STATIC=ON;-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>")
   if(NOT "${CMAKE_TOOLCHAIN_FILE}" STREQUAL "")
-    set(VARTYPES_CMAKE_ARGS "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE};${VARTYPES_CMAKE_ARGS}")
+    set(VarTypes_CMAKE_ARGS "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE};${VarTypes_CMAKE_ARGS}")
   endif()
 
   ExternalProject_Add(vartypes_external
     GIT_REPOSITORY    https://github.com/jpfeltracco/vartypes
     GIT_TAG           origin/jpfeltracco/build_static
-    INSTALL_DIR       "${VARTYPES_INSTALL_DIR}"
-    CMAKE_ARGS        "${VARTYPES_CMAKE_ARGS}"
+    INSTALL_DIR       "${VarTypes_INSTALL_DIR}"
+    CMAKE_ARGS        "${VarTypes_CMAKE_ARGS}"
   )
   add_dependencies(${app} vartypes_external)
 
-  set(VARTYPES_INCLUDE_DIRS "${VARTYPES_INSTALL_DIR}/include")
-  set(VARTYPE_LIB_NAME ${CMAKE_STATIC_LIBRARY_PREFIX}vartypes${CMAKE_STATIC_LIBRARY_SUFFIX})
-  set(VARTYPES_LIBRARIES "${VARTYPES_INSTALL_DIR}/lib/${VARTYPE_LIB_NAME}")
+  set(VarTypes_INCLUDE_DIRS "${VarTypes_INSTALL_DIR}/include")
+  set(VarTypes_LIB_NAME ${CMAKE_STATIC_LIBRARY_PREFIX}vartypes${CMAKE_STATIC_LIBRARY_SUFFIX})
+  set(VarTypes_LIBRARIES "${VarTypes_INSTALL_DIR}/lib/${VARTYPE_LIB_NAME}")
 endif()
 
-target_include_directories(${app} PRIVATE ${VARTYPES_INCLUDE_DIRS})
-list(APPEND libs ${VARTYPES_LIBRARIES})
+target_include_directories(${app} PRIVATE ${VarTypes_INCLUDE_DIRS})
+list(APPEND libs ${VarTypes_LIBRARIES})
 
 # Protobuf
 find_package(Protobuf REQUIRED)
@@ -126,6 +132,12 @@ protobuf_generate_cpp(PROTO_CPP PROTO_H
     src/proto/ssl_vision_geometry.proto
     src/proto/ssl_vision_wrapper.proto
 )
+
+# exclude generated header files from Qt Automoc
+set(GRSIM_AUTOGEN_FILES ${PROTO_H};${PROTO_CPP})
+foreach(protoc_header IN LISTS GRSIM_AUTOGEN_FILES)
+  set_property(SOURCE ${protoc_header} PROPERTY SKIP_AUTOMOC ON)
+endforeach(protoc_header)
 
 qt5_add_resources(RESOURCES
     resources/textures.qrc

--- a/clients/qt/CMakeLists.txt
+++ b/clients/qt/CMakeLists.txt
@@ -20,6 +20,12 @@ protobuf_generate_cpp(PROTO_CPP PROTO_H
     ../../src/proto/grSim_Packet.proto
 )
 
+# exclude generated header files from Qt Automoc
+set(CLIENT_AUTOGEN_FILES ${PROTO_H};${PROTO_CPP})
+foreach(protoc_header IN LISTS CLIENT_AUTOGEN_FILES)
+  set_property(SOURCE ${protoc_header} PROPERTY SKIP_AUTOMOC ON)
+endforeach(protoc_header)
+
 set(app client)
 
 add_executable(${app} MACOSX_BUNDLE

--- a/clients/qt/mainwindow.cpp
+++ b/clients/qt/mainwindow.cpp
@@ -157,7 +157,7 @@ void MainWindow::sendPacket()
     command->set_spinner(chkSpin->isChecked());
 
     QByteArray dgram;
-    dgram.resize(packet.ByteSize());
+    dgram.resize(static_cast<int>(packet.ByteSizeLong()));
     packet.SerializeToArray(dgram.data(), dgram.size());
     udpsocket.writeDatagram(dgram, _addr, _port);
 }

--- a/cmake/modules/FindVarTypes.cmake
+++ b/cmake/modules/FindVarTypes.cmake
@@ -1,5 +1,5 @@
 find_path(
-   VARTYPES_INCLUDE_DIRS
+   VarTypes_INCLUDE_DIRS
    NAMES
    vartypes/VarTypes.h
    HINTS
@@ -10,7 +10,7 @@ find_path(
 )
 
 find_library(
-   VARTYPES_LIBRARY
+   VarTypes_LIBRARY
    NAMES
    vartypes
    HINTS
@@ -20,18 +20,18 @@ find_library(
    $ENV{ProgramFiles}/vartypes/lib
 )
 
-set(VARTYPES_LIBRARIES ${VARTYPES_LIBRARY})
+set(VarTypes_LIBRARIES ${VarTypes_LIBRARY})
 
 find_package_handle_standard_args(
-   VARTYPES
+   VarTypes
    DEFAULT_MSG
-   VARTYPES_INCLUDE_DIRS
-   VARTYPES_LIBRARIES
+   VarTypes_INCLUDE_DIRS
+   VarTypes_LIBRARIES
 )
 
 mark_as_advanced(
-    VARTYPES_INCLUDE_DIRS
-    VARTYPES_LIBRARIES
-    VARTYPES_LIBRARY
+    VarTypes_INCLUDE_DIRS
+    VarTypes_LIBRARIES
+    VarTypes_LIBRARY
 )
 

--- a/include/configwidget.h
+++ b/include/configwidget.h
@@ -45,19 +45,15 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 
 using namespace VarTypes;
 
-
-#ifdef HAVE_MACOSX
-
 #define DEF_VALUE(type,Type,name)  \
             std::shared_ptr<VarTypes::Var##Type> v_##name; \
             inline type name() {return v_##name->get##Type();}
-            
+
 #define DEF_FIELD_VALUE(type,Type,name)  \
             std::shared_ptr<VarTypes::Var##Type> v_DivA_##name; \
             std::shared_ptr<VarTypes::Var##Type> v_DivB_##name; \
             inline type name() {return (Division() == "Division A" ? v_DivA_##name: v_DivB_##name)->get##Type(); }
 
-            
 #define DEF_ENUM(type,name)  \
             std::shared_ptr<VarTypes::VarStringEnum> v_##name; \
             type name() {if(v_##name!=nullptr) return v_##name->getString();return * (new type);}
@@ -66,28 +62,6 @@ using namespace VarTypes;
             std::shared_ptr<VarTypes::VarList> name;
 #define DEF_PTREE(parents, name)  \
             std::shared_ptr<VarTypes::VarList> parents##_##name;
-
-#else
-
-#define DEF_VALUE(type,Type,name)  \
-            std::shared_ptr<VarTypes::Var##Type> v_##name; \
-            inline type name() {return v_##name->get##Type();}
-
-#define DEF_FIELD_VALUE(type,Type,name)  \
-            std::shared_ptr<VarTypes::Var##Type> v_DivA_##name; \
-            std::shared_ptr<VarTypes::Var##Type> v_DivB_##name; \
-            inline type name() {return (Division() == "Division A" ? v_DivA_##name: v_DivB_##name)->get##Type(); }
-
-#define DEF_ENUM(type,name)  \
-            std::shared_ptr<VarTypes::VarStringEnum> v_##name; \
-            type name() {if(v_##name!=NULL) return v_##name->getString();return * (new type);}
-
-#define DEF_TREE(name)  \
-            std::shared_ptr<VarTypes::VarList> name;
-#define DEF_PTREE(parents, name)  \
-            std::shared_ptr<VarTypes::VarList> parents##_##name;
-
-#endif
 
 
 class RobotSettings {

--- a/include/glwidget.h
+++ b/include/glwidget.h
@@ -21,7 +21,7 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 
 #define GL_SILENCE_DEPRECATION
 #include <QGLWidget>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QMenu>
 
 #include "sslworld.h"
@@ -114,7 +114,7 @@ private:
     int moving_robot_id,clicked_robot;
     int frames;
     bool first_time;
-    QTime time,rendertimer;
+    QElapsedTimer time,rendertimer;
     dReal m_fps;
     QPoint lastPos;
 };

--- a/include/statuswidget.h
+++ b/include/statuswidget.h
@@ -25,7 +25,7 @@ Copyright (C) 2011, Parsian Robotic Center (eew.aut.ac.ir/~parsian/grsim)
 #include <QLabel>
 #include <QColor>
 #include <QTextDocument>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QQueue>
 #include <QColor>
 
@@ -69,7 +69,7 @@ public slots:
 
 private:
     CStatusPrinter *statusPrinter;
-    QTime logTime;
+    QElapsedTimer logTime;
 
 };
 

--- a/src/net/robocup_ssl_server.cpp
+++ b/src/net/robocup_ssl_server.cpp
@@ -63,9 +63,8 @@ void RoboCupSSLServer::change_interface(const string & net_interface)
 
 bool RoboCupSSLServer::send(const SSL_WrapperPacket & packet)
 {
-    QByteArray datagram;
+    QByteArray datagram(packet.ByteSizeLong(), 0);
 
-    datagram.resize(packet.ByteSize());
     bool success = packet.SerializeToArray(datagram.data(), datagram.size());
     if(!success) {
         //TODO: print useful info

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -545,7 +545,7 @@ void SSLWorld::addRobotStatus(Robots_Status& robotsPacket, int robotID, bool inf
 }
 
 void SSLWorld::sendRobotStatus(Robots_Status& robotsPacket, const QHostAddress& sender, int team) {
-    int size = robotsPacket.ByteSize();
+    const auto size = robotsPacket.ByteSizeLong();
     QByteArray buffer(size, 0);
     robotsPacket.SerializeToArray(buffer.data(), buffer.size());
     if (team == 0) {
@@ -681,7 +681,7 @@ void SSLWorld::simControlSocketReady() {
         SimulatorResponse response;
         processSimControl(simulatorCommand, response);
         
-        QByteArray buffer(response.ByteSize(), 0);
+        QByteArray buffer(response.ByteSizeLong(), 0);
         response.SerializeToArray(buffer.data(), buffer.size());
         simControlSocket->writeDatagram(buffer.data(), buffer.size(), datagram.senderAddress(), datagram.senderPort());
     }
@@ -699,7 +699,7 @@ void SSLWorld::blueControlSocketReady() {
         RobotControlResponse robotControlResponse;
         processRobotControl(robotControl, robotControlResponse, BLUE);
 
-        QByteArray buffer(robotControlResponse.ByteSize(), 0);
+        QByteArray buffer(robotControlResponse.ByteSizeLong(), 0);
         robotControlResponse.SerializeToArray(buffer.data(), buffer.size());
         blueControlSocket->writeDatagram(buffer.data(), buffer.size(), datagram.senderAddress(), datagram.senderPort());
     }
@@ -717,7 +717,7 @@ void SSLWorld::yellowControlSocketReady() {
         RobotControlResponse robotControlResponse;
         processRobotControl(robotControl, robotControlResponse, YELLOW);
         
-        QByteArray buffer(robotControlResponse.ByteSize(), 0);
+        QByteArray buffer(robotControlResponse.ByteSizeLong(), 0);
         robotControlResponse.SerializeToArray(buffer.data(), buffer.size());
         yellowControlSocket->writeDatagram(buffer.data(), buffer.size(), datagram.senderAddress(), datagram.senderPort());
     }


### PR DESCRIPTION
### Identify the Bug

There're no linked issue.
This is test PR to check if github actions are working for this forked repository.

### Description of the Change

- Deleted duplicated macros.  
  For historical reason (or something. I'm not sure), some macros (`ADD_ENUM`, e.g.) have two patterns - for MacOS and the others.
  Current codes are completely same so we can merge them.
- Suppress CMake warnings
  - CMP0072 are not set : setting this to NEW
  - finding package `VarTypes` are case-sensitive, but both `VARTYPES` and `VarTypes` were used. I've unified them to `VarTypes` based on .cmake filename
  - Explicitly set `SKIP_AUTOMOC = true` to files automatically generated by protobuf
- Suppress Qt deprecated warnings
  QTimer is used to check elapsed time in some widgets but it is deprecated since Qt 5.14.0.  
  QElapsedTimer (introduced in Qt 4.7) is suitable for the situation.

### Alternate Designs

N/A

### Possible Drawbacks

- In this change, CMP0072 is set to NEW so GLVND will be used instead of legacy OpenGL library. Someone may affected (at least I saw no difference).
- QElapsedTimer is only available on Qt 4.7 or later

### Verification Process

Build and run as usual

### Release Notes

N/A